### PR TITLE
Add shot count control

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - 集成 MiniMax-H3 官方基础与完整参考提示词规则。
 - 支持中文 / English 输出。
 - 支持 `strict / balanced / creative` 三档改写。
+- 支持 `AUTO` 或固定 1–20 个镜头的下拉控制。
 - 支持用户参考模板融合，主提示词与可观察媒体事实优先。
 - 提供随机种子以及 `fixed / randomize / increment / decrement` 状态。
 - 提供节点内 API Key 输入、遮罩显示、保存、清空和注册链接。
@@ -46,7 +47,7 @@ MiniMax H3 Prompt Enhancer (Seedance / OpenAI)
 
 1. 添加 `MiniMax H3 Prompt Enhancer (Seedance / OpenAI)`。
 2. 在“视频创意 / 提示词”中输入基础意图。
-3. 选择生成类型、时长、改写模式和输出语言。
+3. 选择生成类型、时长、镜头数量、改写模式和输出语言。
 4. I2VA / FL2VA / L2VA / Ref2VA 按任务要求连接图片或视频。
 5. 填写 API Key，点击“保存到工作流”；或者使用环境变量。
 6. 点击节点底部的“运行提示词优化”。
@@ -97,6 +98,7 @@ MiniMax H3 Prompt Enhancer (Seedance / OpenAI)
 | `prompt` | 用户基础视频意图，不能为空 |
 | `task_type` | T2VA / I2VA / FL2VA / L2VA / Ref2VA |
 | `duration_seconds` | 目标时长，4–15 秒 |
+| `shot_count` | `AUTO` 由模型按内容、素材、时长和节奏判断；也可固定为 1–20 个镜头 |
 | `rewrite_mode` | `strict / balanced / creative` |
 | `description_word_target` | `0` 为自动；非零为 80–1000，中文按约数汉字、英文按单词理解 |
 | `output_language` | `中文 / English`，默认中文 |
@@ -111,6 +113,14 @@ MiniMax H3 Prompt Enhancer (Seedance / OpenAI)
 | `seed` | 随机种子，配合运行后状态控制缓存和变体 |
 
 `reference_context` 和 `constraints` 默认折叠。正常使用不需要填写，避免把简单任务变成大量表单输入。
+
+## 镜头数量
+
+- `AUTO（系统自动判断）`：结合基础提示词、参考素材、目标时长、动作密度和节奏决定镜头数；没有必要切镜时优先使用单镜头内运镜。
+- `1–20`：要求 LLM 在时间线中使用恰好对应数量的 `[Shot N]`，连续编号，并让后续镜头的时间码严格递增且小于目标时长。
+- 固定数量优先于基础提示词或参考模板中的模糊镜头数量范围。选择 `AUTO` 时，基础提示词中的镜头要求仍会参与模型判断。
+
+镜头数量是传给上游模型的明确生成约束，不是本地响应验收条件；只要上游返回非空内容，节点仍按“输出与错误行为”中的规则放行。
 
 ## 随机种子
 

--- a/example/minimax_h3_prompt_enhancer_example.json
+++ b/example/minimax_h3_prompt_enhancer_example.json
@@ -13,7 +13,7 @@
       ],
       "size": [
         400,
-        470
+        500
       ],
       "flags": {},
       "order": 0,
@@ -73,6 +73,15 @@
           "type": "INT",
           "widget": {
             "name": "duration_seconds"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "shot_count",
+          "name": "shot_count",
+          "type": "COMBO",
+          "widget": {
+            "name": "shot_count"
           },
           "link": null
         },
@@ -207,6 +216,7 @@
         "雨夜的霓虹街道上，一名穿红色风衣的女人缓步走向镜头，镜头低机位跟拍，风吹动衣摆，远处雷声与城市环境声交织。",
         "T2VA（文生音视频）",
         5,
+        "AUTO（系统自动判断）",
         "balanced",
         0,
         "中文",

--- a/nodes.py
+++ b/nodes.py
@@ -32,6 +32,8 @@ REWRITE_MODES = ["strict", "balanced", "creative"]
 MODE_TEMPERATURES = {"strict": 0.2, "balanced": 0.7, "creative": 1.2}
 OUTPUT_LANGUAGES = ["中文", "English"]
 PROMPT_MODES = ["官方增强", "参考模板融合"]
+AUTO_SHOT_COUNT = "AUTO（系统自动判断）"
+SHOT_COUNT_OPTIONS = [AUTO_SHOT_COUNT] + [str(count) for count in range(1, 21)]
 SEEDANCE_API_MODE = "贞贞平价小屋（推荐）"
 OPENAI_API_MODE = "OpenAI兼容接口（备用）"
 API_MODES = [SEEDANCE_API_MODE, OPENAI_API_MODE]
@@ -128,6 +130,19 @@ class PromptEnhancerError(RuntimeError):
 def _canonical_task_type(task_type: str) -> str:
     value = str(task_type or "T2VA")
     return TASK_TYPE_ALIASES.get(value, value)
+
+
+def _normalize_shot_count(shot_count: Any) -> int:
+    value = str(shot_count if shot_count is not None else "").strip()
+    if value in {"", "0", "AUTO", "auto", "自动", AUTO_SHOT_COUNT}:
+        return 0
+    try:
+        count = int(value)
+    except (TypeError, ValueError) as error:
+        raise PromptEnhancerError("shot_count must be AUTO or an integer from 1 to 20.") from error
+    if not 1 <= count <= 20:
+        raise PromptEnhancerError("shot_count must be AUTO or an integer from 1 to 20.")
+    return count
 
 
 def _openai_chat_url(base_url: str) -> str:
@@ -544,6 +559,22 @@ def _length_target_instruction(task_type: str, description_word_target: int, out
     return f"Choose a concise but complete length for {field} based on the requested duration and information density."
 
 
+def _shot_count_instruction(shot_count: int) -> str:
+    if shot_count == 0:
+        return (
+            "Shot count mode: AUTO. Decide the most suitable number of timeline shots from the user's intent, "
+            "attached media, target duration, action density, and pacing. Prefer camera movement within one shot "
+            "when a separate cut is not useful."
+        )
+    return (
+        f"Shot count mode: fixed. The timeline must contain exactly {shot_count} shots, numbered consecutively "
+        f"from [Shot 1] through [Shot {shot_count}], with each label appearing exactly once. [Shot 1] has no "
+        "timestamp; every later shot has a valid strictly increasing timestamp below the target duration. This "
+        "explicit fixed count overrides any approximate shot-count number or range in the user's prompt or "
+        "reference template. Do not report or explain the count outside the required timeline."
+    )
+
+
 def _build_user_instruction(
     prompt: str,
     task_type: str,
@@ -557,8 +588,10 @@ def _build_user_instruction(
     constraints: str,
     media_plan: list[dict[str, Any]],
     seed: int,
+    shot_count: int,
 ) -> str:
     media_labels = ", ".join(asset["label"] for asset in media_plan) or "none"
+    shot_count_control = "AUTO" if shot_count == 0 else f"exactly {shot_count}"
     return "\n".join([
         f"H3 task type: {task_type}",
         f"Target duration: {duration_seconds:.2f} seconds",
@@ -567,6 +600,7 @@ def _build_user_instruction(
         f"Prompt construction mode: {prompt_mode}",
         f"Variation seed: {seed}",
         "Use the variation seed only as an opaque tie-breaker for allowed creative choices. Never print it in the result.",
+        f"Shot count control: {shot_count_control}",
         f"Attached media labels: {media_labels}",
         _length_target_instruction(task_type, description_word_target, output_language),
         "Original user intent (preserve its meaning and exact quoted language):",
@@ -595,6 +629,7 @@ def _build_messages(
     media_plan: list[dict[str, Any]],
     media_parts: list[dict[str, Any]],
     seed: int,
+    shot_count: int,
 ) -> list[dict[str, Any]]:
     system_content = "\n\n".join([
         COMMON_SYSTEM_RULES,
@@ -602,6 +637,7 @@ def _build_messages(
         MODE_RULES[rewrite_mode],
         PROMPT_MODE_RULES[prompt_mode],
         TASK_RULES[task_type],
+        _shot_count_instruction(shot_count),
     ])
     user_text = _build_user_instruction(
         prompt,
@@ -616,6 +652,7 @@ def _build_messages(
         constraints,
         media_plan,
         seed,
+        shot_count,
     )
     user_content: str | list[dict[str, Any]]
     if media_parts:
@@ -719,8 +756,10 @@ def enhance_prompt(
     openai_base_url: str = "",
     openai_upload_url: str = "",
     seed: int = 0,
+    shot_count: Any = AUTO_SHOT_COUNT,
 ) -> str:
     task_type = _canonical_task_type(task_type)
+    shot_count = _normalize_shot_count(shot_count)
     output_language = str(output_language or "中文")
     prompt_mode = str(prompt_mode or "官方增强")
     api_key = str(api_key or "").strip()
@@ -792,6 +831,7 @@ def enhance_prompt(
             media_plan,
             media_parts,
             seed,
+            shot_count,
         )
         response_text = _request_completion(session, api_key, messages, rewrite_mode, chat_url, provider_name)
         return _reorder_complete_fields(response_text, task_type)
@@ -827,6 +867,13 @@ class MiniMaxH3PromptEnhancer(io.ComfyNode):
                     default=TASK_TYPE_LABELS["T2VA"],
                 ),
                 io.Int.Input("duration_seconds", display_name="目标时长（秒）", default=5, min=4, max=15, step=1),
+                io.Combo.Input(
+                    "shot_count",
+                    display_name="镜头数量",
+                    options=SHOT_COUNT_OPTIONS,
+                    default=AUTO_SHOT_COUNT,
+                    tooltip="AUTO 由模型结合时长、内容与节奏判断；1-20 要求输出对应数量的 [Shot N]。",
+                ),
                 io.Combo.Input("rewrite_mode", display_name="改写模式", options=REWRITE_MODES, default="balanced"),
                 io.Int.Input(
                     "description_word_target",
@@ -951,6 +998,7 @@ class MiniMaxH3PromptEnhancer(io.ComfyNode):
         openai_base_url="",
         openai_upload_url="",
         seed=0,
+        shot_count=AUTO_SHOT_COUNT,
     ) -> io.NodeOutput:
         result = enhance_prompt(
             prompt=prompt,
@@ -972,6 +1020,7 @@ class MiniMaxH3PromptEnhancer(io.ComfyNode):
             openai_base_url=openai_base_url,
             openai_upload_url=openai_upload_url,
             seed=seed,
+            shot_count=shot_count,
         )
         return io.NodeOutput(result)
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -184,6 +184,7 @@ class PromptEnhancerTests(unittest.TestCase):
         self.assertIn("openai_base_url", input_names)
         self.assertIn("openai_upload_url", input_names)
         self.assertIn("seed", input_names)
+        self.assertIn("shot_count", input_names)
         self.assertLess(input_names.index("api_key"), input_names.index("output_language"))
         self.assertEqual([output.display_name for output in schema.outputs], ["enhanced_prompt"])
         images = next(item for item in schema.inputs if item.id == "reference_images")
@@ -196,6 +197,7 @@ class PromptEnhancerTests(unittest.TestCase):
         task_type = next(item for item in schema.inputs if item.id == "task_type")
         api_mode = next(item for item in schema.inputs if item.id == "api_mode")
         seed = next(item for item in schema.inputs if item.id == "seed")
+        shot_count = next(item for item in schema.inputs if item.id == "shot_count")
         self.assertEqual((images.template.min, images.template.max), (0, 9))
         self.assertEqual((videos.template.min, videos.template.max), (0, 3))
         self.assertTrue(api_key.socketless)
@@ -209,6 +211,10 @@ class PromptEnhancerTests(unittest.TestCase):
         self.assertTrue(seed.optional)
         self.assertEqual((seed.default, seed.min, seed.max), (0, 0, 0xffffffffffffffff))
         self.assertTrue(seed.control_after_generate)
+        self.assertEqual(shot_count.default, nodes.AUTO_SHOT_COUNT)
+        self.assertEqual(shot_count.options, nodes.SHOT_COUNT_OPTIONS)
+        self.assertEqual(shot_count.options[1:], [str(count) for count in range(1, 21)])
+        self.assertEqual(input_names.index("shot_count"), input_names.index("duration_seconds") + 1)
 
     def test_frontend_masks_api_key_and_has_signup_button(self):
         source = (NODES_PATH.parent / "web" / "js" / "minimax_h3_prompt_enhancer.js").read_text(encoding="utf-8")
@@ -240,6 +246,10 @@ class PromptEnhancerTests(unittest.TestCase):
         self.assertIn('delete secureWidget.width', source)
         self.assertIn('"control_after_generate"', source)
         self.assertIn('seedControlWidget.label = "种子状态（运行后）"', source)
+        self.assertIn('const AUTO_SHOT_COUNT = "AUTO（系统自动判断）"', source)
+        self.assertIn('"shot_count"', source)
+        self.assertIn("serialized.widgets_values.length === 16", source)
+        self.assertIn("widgets_values.splice(3, 0, AUTO_SHOT_COUNT)", source)
         self.assertIn('widget.element.style.display = visible ? widget.t8OriginalDisplay : "none"', source)
         self.assertIn("widget.hidden = visible ? widget.t8OriginalHidden : true", source)
 
@@ -249,9 +259,10 @@ class PromptEnhancerTests(unittest.TestCase):
         workflow = json.loads(source)
         node = workflow["nodes"][0]
         self.assertEqual(node["type"], "MiniMaxH3PromptEnhancerT8")
-        self.assertEqual(len(node["widgets_values"]), 16)
+        self.assertEqual(len(node["widgets_values"]), 17)
         self.assertEqual(node["widgets_values"][1], "T2VA（文生音视频）")
-        self.assertEqual(node["widgets_values"][5:8], ["中文", "官方增强", nodes.SEEDANCE_API_MODE])
+        self.assertEqual(node["widgets_values"][3], nodes.AUTO_SHOT_COUNT)
+        self.assertEqual(node["widgets_values"][6:9], ["中文", "官方增强", nodes.SEEDANCE_API_MODE])
         self.assertEqual(node["widgets_values"][-2:], [0, "randomize"])
         self.assertNotRegex(source, r"sk-[A-Za-z0-9_-]{8,}")
 
@@ -334,6 +345,23 @@ class PromptEnhancerTests(unittest.TestCase):
             first_request["messages"][1]["content"],
             second_session.chat_requests[0]["json"]["messages"][1]["content"],
         )
+
+    def test_auto_and_fixed_shot_count_rules_reach_the_model(self):
+        auto_session = FakeSession(basic_output())
+        self.run_enhancer(auto_session)
+        auto_messages = auto_session.chat_requests[0]["json"]["messages"]
+        self.assertIn("Shot count mode: AUTO", auto_messages[0]["content"])
+        self.assertIn("Shot count control: AUTO", auto_messages[1]["content"])
+
+        fixed_session = FakeSession(basic_output())
+        result = self.run_enhancer(fixed_session, shot_count="12")
+        fixed_request = fixed_session.chat_requests[0]["json"]
+        self.assertEqual(result, basic_output())
+        self.assertNotIn("shot_count", fixed_request)
+        self.assertIn("exactly 12 shots", fixed_request["messages"][0]["content"])
+        self.assertIn("from [Shot 1] through [Shot 12]", fixed_request["messages"][0]["content"])
+        self.assertIn("overrides any approximate shot-count number or range", fixed_request["messages"][0]["content"])
+        self.assertIn("Shot count control: exactly 12", fixed_request["messages"][1]["content"])
 
     def test_labeled_task_type_is_normalized_to_the_fixed_h3_contract(self):
         session = FakeSession(basic_output())
@@ -605,7 +633,7 @@ class PromptEnhancerTests(unittest.TestCase):
                 self.assertEqual(session.uploads, [])
                 self.assertEqual(session.chat_requests, [])
 
-    def test_duration_and_word_target_boundaries(self):
+    def test_duration_word_target_and_shot_count_boundaries(self):
         four_second = FakeSession(basic_output(shots=2))
         self.run_enhancer(four_second, duration_seconds=4)
         fifteen_second_output = basic_output(shots=2).replace("00:03.000", "00:14.999")
@@ -616,6 +644,9 @@ class PromptEnhancerTests(unittest.TestCase):
             {"duration_seconds": 16},
             {"description_word_target": 79},
             {"description_word_target": 1001},
+            {"shot_count": -1},
+            {"shot_count": 21},
+            {"shot_count": "many"},
         ):
             with self.subTest(kwargs=kwargs):
                 session = FakeSession(basic_output())

--- a/web/js/minimax_h3_prompt_enhancer.js
+++ b/web/js/minimax_h3_prompt_enhancer.js
@@ -5,6 +5,8 @@ const NODE_ID = "MiniMaxH3PromptEnhancerT8";
 const SIGN_UP_URL = "https://api.seedance.nz/sign-up?aff=5f4w";
 const SEEDANCE_API_MODE = "贞贞平价小屋（推荐）";
 const OPENAI_API_MODE = "OpenAI兼容接口（备用）";
+const AUTO_SHOT_COUNT = "AUTO（系统自动判断）";
+const SHOT_COUNT_OPTIONS = [AUTO_SHOT_COUNT, ...Array.from({ length: 20 }, (_, index) => String(index + 1))];
 const TASK_TYPE_LABELS = {
     T2VA: "T2VA（文生音视频）",
     I2VA: "I2VA（首帧图生音视频）",
@@ -18,6 +20,7 @@ const SERIALIZED_WIDGET_NAMES = [
     "prompt",
     "task_type",
     "duration_seconds",
+    "shot_count",
     "rewrite_mode",
     "description_word_target",
     "output_language",
@@ -315,6 +318,7 @@ app.registerExtension({
 
             const outputLanguageWidget = this.widgets?.find((widget) => widget.name === "output_language");
             const taskTypeWidget = this.widgets?.find((widget) => widget.name === "task_type");
+            const shotCountWidget = this.widgets?.find((widget) => widget.name === "shot_count");
             const promptModeWidget = this.widgets?.find((widget) => widget.name === "prompt_mode");
             const referenceTemplateWidget = this.widgets?.find((widget) => widget.name === "reference_template");
             const referenceContextWidget = this.widgets?.find((widget) => widget.name === "reference_context");
@@ -339,6 +343,7 @@ app.registerExtension({
             this.t8NormalizePromptOptions = () => {
                 if (TASK_TYPE_LABELS[taskTypeWidget?.value]) taskTypeWidget.value = TASK_TYPE_LABELS[taskTypeWidget.value];
                 normalizeChoice(taskTypeWidget, Object.values(TASK_TYPE_LABELS), TASK_TYPE_LABELS.T2VA);
+                normalizeChoice(shotCountWidget, SHOT_COUNT_OPTIONS, AUTO_SHOT_COUNT);
                 normalizeChoice(outputLanguageWidget, ["中文", "English"], "中文");
                 normalizeChoice(promptModeWidget, ["官方增强", "参考模板融合"], "官方增强");
                 normalizeChoice(apiModeWidget, [SEEDANCE_API_MODE, OPENAI_API_MODE], SEEDANCE_API_MODE);
@@ -393,7 +398,13 @@ app.registerExtension({
             resizeNode(this);
         };
         nodeType.prototype.onConfigure = function () {
-            originalOnConfigure?.apply(this, arguments);
+            const args = [...arguments];
+            const serialized = args[0];
+            if (Array.isArray(serialized?.widgets_values) && serialized.widgets_values.length === 16) {
+                args[0] = { ...serialized, widgets_values: [...serialized.widgets_values] };
+                args[0].widgets_values.splice(3, 0, AUTO_SHOT_COUNT);
+            }
+            originalOnConfigure?.apply(this, args);
             requestAnimationFrame(() => this.t8NormalizePromptOptions?.());
         };
         nodeType.prototype.onSerialize = function (serialized) {


### PR DESCRIPTION
## What changed

- add an AUTO or fixed 1–20 shot-count dropdown
- send the selected shot-count rule to both system and user LLM instructions
- migrate existing 16-value workflows to AUTO without shifting later settings
- update the example workflow, README, and regression coverage

## User impact

Users can let the model choose the shot count or request an exact number of `[Shot N]` timeline entries. Non-empty upstream output is still passed through even if the model does not fully follow the requested count.

## Checks

- 46 unit tests
- Python compile check
- JavaScript syntax check
- example workflow JSON parse
- staged secret scan