### PR TITLE
fix: retry transient API failures across network routes

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1,11 +1,11 @@
 import base64
 import io as python_io
 import json
+import logging
 import os
 import re
 import time
 from typing import Any
-from urllib.parse import urlsplit
 
 import numpy as np
 import requests
@@ -30,8 +30,12 @@ CUSTOM_MODEL_OPTION = "Custom（自定义）"
 AI_WORKSHOP_MODEL_OPTIONS = [AI_WORKSHOP_DEFAULT_MODEL, CUSTOM_MODEL_OPTION]
 MAX_FILE_BYTES = 50 * 1024 * 1024
 REQUEST_TIMEOUT = (20, 300)
-SEEDANCE_CHAT_RETRY_DELAYS = (0.5, 1.0)
-SEEDANCE_CHAT_RETRYABLE_STATUS_CODES = frozenset({502, 503, 504})
+REQUEST_ROUTE_SEQUENCE = ("direct", "proxy", "direct", "proxy")
+RETRY_DELAYS_SECONDS = (1, 5, 10)
+RETRYABLE_HTTP_STATUSES = frozenset({429, 502, 503, 504})
+DIRECT_PROXIES = {"http": "", "https": "", "all": ""}
+
+LOGGER = logging.getLogger(__name__)
 
 TASK_TYPES = ["T2VA", "I2VA", "FL2VA", "L2VA", "Ref2VA"]
 TASK_TYPE_LABELS = {
@@ -710,30 +714,44 @@ def _raise_http_error(
     raise PromptEnhancerError(f"{provider_name} {operation} {label} (HTTP {status}): {detail}")
 
 
-def _is_seedance_chat_endpoint(chat_url: str) -> bool:
-    try:
-        parsed = urlsplit(str(chat_url or ""))
-    except ValueError:
-        return False
-    return (
-        (parsed.hostname or "").lower() == "api.seedance.nz"
-        and parsed.path.rstrip("/") == "/v1/chat/completions"
-    )
+def _route_proxies(url: str, route: str) -> dict[str, str]:
+    if route == "direct":
+        return DIRECT_PROXIES
+    return requests.utils.get_environ_proxies(url)
 
 
-def _is_retryable_seedance_network_error(error: requests.RequestException) -> bool:
-    # A read timeout is deliberately excluded: the server may already have
-    # completed the paid generation even though its response did not arrive.
-    if isinstance(error, requests.exceptions.ReadTimeout):
-        return False
+def _is_retryable_network_error(error: requests.RequestException) -> bool:
     return isinstance(
         error,
         (
-            requests.exceptions.SSLError,
-            requests.exceptions.ConnectTimeout,
-            requests.exceptions.ConnectionError,
+            requests.ConnectionError,
+            requests.Timeout,
+            requests.exceptions.ChunkedEncodingError,
+            requests.exceptions.ContentDecodingError,
         ),
     )
+
+
+def _post_on_route(
+    session: requests.Session,
+    url: str,
+    route: str,
+    **kwargs: Any,
+) -> requests.Response:
+    """Use an isolated production session for every direct/proxy attempt."""
+    if isinstance(session, requests.Session):
+        attempt_session = requests.Session()
+        attempt_session.trust_env = route == "proxy"
+        try:
+            return attempt_session.post(url, **kwargs)
+        finally:
+            attempt_session.close()
+    kwargs["proxies"] = _route_proxies(url, route)
+    return session.post(url, **kwargs)
+
+
+def _wait_before_retry(attempt: int) -> None:
+    time.sleep(RETRY_DELAYS_SECONDS[attempt - 1])
 
 
 def _upload_media(
@@ -748,21 +766,41 @@ def _upload_media(
     if len(data) > MAX_FILE_BYTES:
         raise PromptEnhancerError(f"{filename} exceeds the Seedance 50 MB upload limit.")
     response = None
-    for attempt in range(2):
+    attempted_routes: list[str] = []
+    for attempt, route in enumerate(REQUEST_ROUTE_SEQUENCE, start=1):
+        attempted_routes.append(route)
         try:
-            response = session.post(
+            response = _post_on_route(
+                session,
                 upload_url,
+                route,
                 headers={"Authorization": f"Bearer {api_key}"},
                 files={"file": (filename, data, mime_type)},
                 timeout=REQUEST_TIMEOUT,
+                allow_redirects=False,
             )
         except requests.RequestException as error:
-            raise PromptEnhancerError(f"{provider_name} media upload network error: {type(error).__name__}") from error
-        if response.status_code != 429 or attempt == 1:
-            break
-        retry_after = str(getattr(response, "headers", {}).get("Retry-After", "")).strip()
-        wait_seconds = int(retry_after) if retry_after.isdigit() else 60
-        time.sleep(min(max(wait_seconds, 1), 60))
+            LOGGER.warning(
+                "%s media upload attempt %d/%d via %s failed: %s",
+                provider_name,
+                attempt,
+                len(REQUEST_ROUTE_SEQUENCE),
+                route,
+                type(error).__name__,
+            )
+            if _is_retryable_network_error(error) and attempt < len(REQUEST_ROUTE_SEQUENCE):
+                _wait_before_retry(attempt)
+                continue
+            routes = " -> ".join(attempted_routes)
+            raise PromptEnhancerError(
+                f"{provider_name} media upload network error after {routes}: {type(error).__name__}"
+            ) from error
+        if response.status_code in RETRYABLE_HTTP_STATUSES and attempt < len(REQUEST_ROUTE_SEQUENCE):
+            response.close()
+            _wait_before_retry(attempt)
+            continue
+        break
+    assert response is not None
     if response.status_code != 200:
         _raise_http_error(response, api_key, "media upload", provider_name)
     try:
@@ -1039,45 +1077,46 @@ def _request_completion(
         "temperature": MODE_TEMPERATURES[rewrite_mode],
         "stream": False,
     }
-    retry_delays = SEEDANCE_CHAT_RETRY_DELAYS if _is_seedance_chat_endpoint(chat_url) else ()
-    attempt = 0
-    while True:
-        attempt += 1
+    response = None
+    attempted_routes: list[str] = []
+    for attempt, route in enumerate(REQUEST_ROUTE_SEQUENCE, start=1):
+        attempted_routes.append(route)
         try:
-            response = session.post(
+            response = _post_on_route(
+                session,
                 chat_url,
+                route,
                 headers={
                     "Authorization": f"Bearer {api_key}",
                     "Content-Type": "application/json",
                 },
                 json=payload,
                 timeout=REQUEST_TIMEOUT,
+                allow_redirects=False,
             )
         except requests.RequestException as error:
-            can_retry = _is_retryable_seedance_network_error(error)
-            if can_retry and attempt <= len(retry_delays):
-                time.sleep(retry_delays[attempt - 1])
+            LOGGER.warning(
+                "%s chat attempt %d/%d via %s failed: %s; replay may incur duplicate chat billing",
+                provider_name,
+                attempt,
+                len(REQUEST_ROUTE_SEQUENCE),
+                route,
+                type(error).__name__,
+            )
+            if _is_retryable_network_error(error) and attempt < len(REQUEST_ROUTE_SEQUENCE):
+                _wait_before_retry(attempt)
                 continue
-            if can_retry and retry_delays:
-                retry_note = f"Fast retry was exhausted after {attempt} attempts."
-            elif isinstance(error, requests.exceptions.ReadTimeout):
-                retry_note = (
-                    "The response state is ambiguous, so it was not retried automatically "
-                    "to avoid a duplicate paid generation."
-                )
-            else:
-                retry_note = "The paid request was not retried automatically."
+            routes = " -> ".join(attempted_routes)
             raise PromptEnhancerError(
-                f"{provider_name} chat network error: {type(error).__name__}. {retry_note}"
+                f"{provider_name} chat network error after {routes}: {type(error).__name__}. "
+                "The request may have incurred duplicate chat billing."
             ) from error
-
-        if (
-            response.status_code in SEEDANCE_CHAT_RETRYABLE_STATUS_CODES
-            and attempt <= len(retry_delays)
-        ):
-            time.sleep(retry_delays[attempt - 1])
+        if response.status_code in RETRYABLE_HTTP_STATUSES and attempt < len(REQUEST_ROUTE_SEQUENCE):
+            response.close()
+            _wait_before_retry(attempt)
             continue
         break
+    assert response is not None
     if response.status_code != 200:
         _raise_http_error(response, api_key, "chat", provider_name, attempts=attempt)
     try:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -38,6 +38,9 @@ class FakeResponse:
             raise self.payload
         return self.payload
 
+    def close(self):
+        return None
+
 
 class FakeSession:
     def __init__(self, completion, chat_status=200, chat_payload=None, chat_exception=None, upload_status=200):
@@ -1126,21 +1129,37 @@ class PromptEnhancerTests(unittest.TestCase):
         self.assertEqual(self.run_enhancer(session, description_word_target=350), short_output)
         self.assertEqual(len(session.chat_requests), 1)
 
-    def test_non_retryable_http_errors_are_actionable_and_do_not_retry_chat(self):
-        for status, phrase in ((401, "configured API Key"), (402, "insufficient balance"), (429, "rate limited")):
+    def test_business_http_errors_are_actionable_and_do_not_retry_chat(self):
+        for status, phrase in ((400, "request rejected"), (401, "configured API Key"), (402, "insufficient balance")):
             with self.subTest(status=status):
                 session = FakeSession("", chat_status=status)
                 with self.assertRaisesRegex(nodes.PromptEnhancerError, phrase):
                     self.run_enhancer(session)
                 self.assertEqual(len(session.chat_requests), 1)
 
+    def test_temporary_http_errors_retry_chat_on_all_routes(self):
+        for status, phrase in ((429, "rate limited"), (502, "gateway failure"), (503, "service unavailable"), (504, "gateway timeout")):
+            with self.subTest(status=status):
+                session = FakeSession("", chat_status=status)
+                with patch.object(nodes.time, "sleep") as sleep:
+                    with self.assertRaisesRegex(nodes.PromptEnhancerError, phrase):
+                        self.run_enhancer(session)
+                self.assertEqual(len(session.chat_requests), 4)
+                self.assertEqual(
+                    [call.args[0] for call in sleep.call_args_list],
+                    [1, 5, 10],
+                )
+
+        gateway = FakeSession(
+            "",
+            chat_status=502,
+            chat_payload=ValueError("not json"),
+        )
         gateway_response = FakeResponse(502, ValueError("not json"), text="<html><h1>502 Bad Gateway</h1><p>nginx</p></html>")
-        gateway = SequencedChatSession([gateway_response, gateway_response, gateway_response])
-        with patch.object(nodes.time, "sleep") as sleep:
-            with self.assertRaisesRegex(nodes.PromptEnhancerError, "after 3 automatic attempts") as raised:
+        gateway.post = lambda url, **kwargs: gateway_response
+        with patch.object(nodes.time, "sleep"):
+            with self.assertRaisesRegex(nodes.PromptEnhancerError, "after 4 automatic attempts") as raised:
                 self.run_enhancer(gateway)
-        self.assertEqual(len(gateway.chat_requests), 3)
-        self.assertEqual([args[0] for args, _ in sleep.call_args_list], [0.5, 1.0])
         self.assertNotIn("<html>", str(raised.exception))
 
     def test_seedance_ssl_retry_returns_the_successful_generation(self):
@@ -1154,7 +1173,7 @@ class PromptEnhancerTests(unittest.TestCase):
         with patch.object(nodes.time, "sleep") as sleep:
             self.assertEqual(self.run_enhancer(session), expected)
         self.assertEqual(len(session.chat_requests), 3)
-        self.assertEqual([args[0] for args, _ in sleep.call_args_list], [0.5, 1.0])
+        self.assertEqual([args[0] for args, _ in sleep.call_args_list], [1, 5])
 
     def test_seedance_gateway_retry_returns_the_successful_generation(self):
         expected = basic_output()
@@ -1167,15 +1186,17 @@ class PromptEnhancerTests(unittest.TestCase):
         with patch.object(nodes.time, "sleep") as sleep:
             self.assertEqual(self.run_enhancer(session), expected)
         self.assertEqual(len(session.chat_requests), 3)
-        self.assertEqual([args[0] for args, _ in sleep.call_args_list], [0.5, 1.0])
+        self.assertEqual([args[0] for args, _ in sleep.call_args_list], [1, 5])
 
-    def test_custom_openai_endpoint_does_not_inherit_seedance_paid_retry_policy(self):
+    def test_custom_openai_endpoint_uses_the_same_four_route_retry_policy(self):
         session = SequencedChatSession([
             requests.exceptions.SSLError("custom provider TLS failure"),
+            FakeResponse(502, {"error": {"message": "bad gateway"}}),
+            FakeResponse(503, {"error": {"message": "unavailable"}}),
             FakeResponse(200, {"choices": [{"message": {"content": basic_output()}}]}),
         ])
-        with self.assertRaisesRegex(nodes.PromptEnhancerError, "not retried automatically"):
-            nodes._request_completion(
+        with patch.object(nodes.time, "sleep") as sleep:
+            result = nodes._request_completion(
                 session,
                 "secret-key",
                 [{"role": "user", "content": "hello"}],
@@ -1183,7 +1204,9 @@ class PromptEnhancerTests(unittest.TestCase):
                 chat_url="https://llm.example/v1/chat/completions",
                 provider_name="OpenAI-compatible",
             )
-        self.assertEqual(len(session.chat_requests), 1)
+        self.assertEqual(result, basic_output())
+        self.assertEqual(len(session.chat_requests), 4)
+        self.assertEqual([args[0] for args, _ in sleep.call_args_list], [1, 5, 10])
 
     def test_http_error_redacts_api_keys(self):
         leaked_key = "sk-" + "leaked-value-1234567890"
@@ -1197,11 +1220,37 @@ class PromptEnhancerTests(unittest.TestCase):
         self.assertNotIn("secret-key", str(raised.exception))
         self.assertNotIn(leaked_key, str(raised.exception))
 
-    def test_timeout_is_not_retried(self):
-        session = FakeSession("", chat_exception=requests.exceptions.ReadTimeout("secret-key must not leak"))
-        with self.assertRaisesRegex(nodes.PromptEnhancerError, "response state is ambiguous"):
-            self.run_enhancer(session)
-        self.assertEqual(len(session.chat_requests), 1)
+    def test_timeout_retries_all_chat_routes(self):
+        session = FakeSession("", chat_exception=requests.Timeout("secret-key must not leak"))
+        with patch.object(nodes.time, "sleep") as sleep:
+            with self.assertRaisesRegex(nodes.PromptEnhancerError, "duplicate chat billing"):
+                self.run_enhancer(session)
+        self.assertEqual(len(session.chat_requests), 4)
+        self.assertEqual(
+            [call.args[0] for call in sleep.call_args_list], [1, 5, 10]
+        )
+
+    def test_chat_network_failure_alternates_direct_and_proxy(self):
+        class RoutingChatSession(FakeSession):
+            def __init__(self):
+                super().__init__(basic_output())
+                self.routes = []
+
+            def post(self, url, **kwargs):
+                if "json" in kwargs:
+                    self.routes.append(kwargs["proxies"])
+                    raise requests.ConnectTimeout("ambiguous route failure")
+                return super().post(url, **kwargs)
+
+        proxy = {"https": "http://proxy.internal:3128"}
+        session = RoutingChatSession()
+        with patch.object(nodes.requests.utils, "get_environ_proxies", return_value=proxy), patch.object(nodes.time, "sleep"):
+            with self.assertRaisesRegex(nodes.PromptEnhancerError, "duplicate chat billing"):
+                self.run_enhancer(session)
+        self.assertEqual(
+            session.routes,
+            [nodes.DIRECT_PROXIES, proxy, nodes.DIRECT_PROXIES, proxy],
+        )
 
     def test_free_upload_429_retries_once_without_duplicate_chat(self):
         class RateLimitedUploadSession(FakeSession):
@@ -1218,6 +1267,58 @@ class PromptEnhancerTests(unittest.TestCase):
         sleep.assert_called_once_with(1)
         self.assertEqual(len(session.uploads), 2)
         self.assertEqual(len(session.chat_requests), 1)
+
+    def test_free_upload_network_failures_alternate_direct_and_proxy(self):
+        class RoutingUploadSession(FakeSession):
+            def __init__(self):
+                super().__init__(basic_output("I2VA"))
+                self.routes = []
+
+            def post(self, url, **kwargs):
+                if url == nodes.UPLOAD_URL:
+                    self.routes.append(kwargs["proxies"])
+                    if len(self.routes) < 4:
+                        raise requests.ConnectTimeout("temporary route failure")
+                return super().post(url, **kwargs)
+
+        proxy = {"https": "http://proxy.internal:3128"}
+        session = RoutingUploadSession()
+        with patch.object(nodes.requests.utils, "get_environ_proxies", return_value=proxy):
+            with patch.object(nodes.time, "sleep") as sleep:
+                self.run_enhancer(session, task_type="I2VA", first_frame=torch.zeros((1, 1, 1, 3)))
+
+        self.assertEqual(
+            session.routes,
+            [nodes.DIRECT_PROXIES, proxy, nodes.DIRECT_PROXIES, proxy],
+        )
+        self.assertEqual([call.args[0] for call in sleep.call_args_list], [1, 5, 10])
+        self.assertEqual(len(session.uploads), 1)
+        self.assertEqual(len(session.chat_requests), 1)
+
+    def test_free_upload_reports_all_failed_routes(self):
+        class FailedUploadSession(FakeSession):
+            def __init__(self):
+                super().__init__(basic_output("I2VA"))
+                self.routes = []
+
+            def post(self, url, **kwargs):
+                if url == nodes.UPLOAD_URL:
+                    self.routes.append(kwargs["proxies"])
+                    raise requests.ReadTimeout("temporary route failure")
+                return super().post(url, **kwargs)
+
+        session = FailedUploadSession()
+        with patch.object(nodes.requests.utils, "get_environ_proxies", return_value={"https": "http://proxy"}):
+            with patch.object(nodes.time, "sleep") as sleep:
+                with self.assertRaisesRegex(
+                    nodes.PromptEnhancerError,
+                    "direct -> proxy -> direct -> proxy: ReadTimeout",
+                ):
+                    self.run_enhancer(session, task_type="I2VA", first_frame=torch.zeros((1, 1, 1, 3)))
+
+        self.assertEqual(len(session.routes), 4)
+        self.assertEqual(len(session.chat_requests), 0)
+        self.assertEqual([call.args[0] for call in sleep.call_args_list], [1, 5, 10])
 
     def test_invalid_json_and_empty_responses_fail_but_length_content_is_returned(self):
         payloads = [


### PR DESCRIPTION
## Summary

- retry transient upload and chat failures across direct and configured proxy routes
- use the fixed direct → proxy → direct → proxy order with 1s, 5s, and 10s delays
- retry transport failures and HTTP 429/502/503/504 while leaving permanent failures single-attempt
- use fresh production sessions for every route attempt

## Why

Temporary gateway failures, rate limits, connection resets, and TLS EOF errors currently abort requests immediately. The route-aware retry flow makes the node resilient to those short-lived failures.

Chat requests are not inherently idempotent, so a timeout after the server accepted a request can result in duplicate billing. The implementation logs an explicit warning when such a retry occurs.

## Validation

- 85 Python tests passed
- 2 frontend tests passed
- verified four-attempt route order and delay sequence
- verified HTTP 500 and permanent 4xx responses are not retried
