### PR TITLE
fix: support /vN-versioned OpenAI-compatible base URLs (e.g. Volcano Ark /api/v3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ AI 工坊模式不需要上传 URL。图片和完整视频以 Base64 Data URL �
 
 ### OpenAI 兼容接口（备用）
 
-备用模式只需一个 API Base URL 和模型 ID。Base URL 支持服务根地址、以 `/v1` 结尾的地址，或完整 `/chat/completions` 地址。节点 Key 留空时读取 `OPENAI_API_KEY`，Base URL 留空时读取 `OPENAI_BASE_URL`；模型 ID 必须在节点中填写供应商实际支持的视觉模型。
+备用模式只需一个 API Base URL 和模型 ID。Base URL 支持服务根地址、以 `/vN` 版本段结尾的地址（如 `/v1`、火山方舟的 `/api/v3`），或完整 `/chat/completions` 地址。节点 Key 留空时读取 `OPENAI_API_KEY`，Base URL 留空时读取 `OPENAI_BASE_URL`；模型 ID 必须在节点中填写供应商实际支持的视觉模型。
 
 #### 修复后的节点配置
 
@@ -436,7 +436,7 @@ MiniMax H3 与 Seedance 2.0 两个节点使用相同的 OpenAI 兼容配置：
 | --- | --- | --- |
 | `API Key` | 是 | 可连接任意 `STRING`，也可在节点内填写；节点留空时读取 `OPENAI_API_KEY` |
 | `OpenAI 模型 ID` | 是 | 填写兼容服务商提供的完整视觉模型 ID，不再固定为 `bytedance/doubao-seed-evolving` |
-| `OpenAI Base URL` | 是 | 只填写一个聊天接口地址；节点会把服务根地址或 `/v1` 地址规范化为 `/v1/chat/completions` |
+| `OpenAI Base URL` | 是 | 只填写一个聊天接口地址；节点会把服务根地址或任意 `/vN` 版本化地址规范化为 `/chat/completions` |
 | `视频素材 URL` | 否 | 仅用于视频，每行一个，按已连接 `VIDEO` 的顺序对应；未填写的已连接视频自动使用 Base64 |
 
 不再需要、也不要填写单独的“兼容素材上传 URL”。图片没有素材 URL 字段，始终由节点编码成 Base64 并随聊天请求直接发送。

--- a/nodes.py
+++ b/nodes.py
@@ -349,7 +349,9 @@ def _openai_chat_url(base_url: str) -> str:
         raise PromptEnhancerError("OpenAI-compatible Base URL must begin with http:// or https://.")
     if base_url.endswith("/chat/completions"):
         return base_url
-    if base_url.endswith("/v1"):
+    if re.search(r"/v\d+$", base_url):
+        # Handles /v1, /v2, /v3, ... bases such as Volcano Ark's /api/v3,
+        # where the OpenAI-compatible path is <base>/chat/completions.
         return f"{base_url}/chat/completions"
     return f"{base_url}/v1/chat/completions"
 


### PR DESCRIPTION
## 问题

`_openai_chat_url` 只识别以 `/v1` 结尾的 Base URL，其他版本化地址会被错误拼成 `<base>/v1/chat/completions`。

例如火山方舟（Volcano Ark）官方文档给出的 Base URL 是 `https://ark.cn-beijing.volces.com/api/v3`，节点会请求：

```
https://ark.cn-beijing.volces.com/api/v3/v1/chat/completions
```

多了一层 `/v1`，服务端返回 HTTP 404（空响应体），报错 `OpenAI-compatible provider chat request failed (HTTP 404)`。

## 修复

将判断从 `endswith("/v1")` 放宽为匹配任意 `/vN` 版本段（`re.search(r"/v\d+$", base_url)`），统一追加 `/chat/completions`：

- `https://ark.cn-beijing.volces.com/api/v3` → `…/api/v3/chat/completions` ✅
- `https://gateway.example/v1` → `…/v1/chat/completions`（行为不变）
- `https://gateway.example` → `…/v1/chat/completions`（行为不变）
- 完整 `/chat/completions` 地址原样使用（行为不变）

README 同步更新了 Base URL 填写说明。

## 验证

- 本地 70 个单元测试全部通过（`tests/test_nodes.py`）
- 修复对两个节点（MiniMax H3 / Seedance 2.0）同时生效，因为 `seedance20.py` 复用 `nodes.py` 中的 `_openai_chat_url`