### PR TITLE
fix: sample inline videos into image_url frames in OpenAI-compatible mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,18 +681,18 @@ MiniMax H3 与 Seedance 2.0 两个节点使用相同的 OpenAI 兼容配置：
 | `API Key` | 是 | 可连接任意 `STRING`，也可在节点内填写；节点留空时读取 `OPENAI_API_KEY` |
 | `OpenAI 模型 ID` | 是 | 填写兼容服务商提供的完整视觉模型 ID，不再固定为 `bytedance/doubao-seed-evolving` |
 | `OpenAI Base URL` | 是 | 只填写一个聊天接口地址；服务根地址补全为 `/v1/chat/completions`，已有 `/vN` 版本段则直接追加 `/chat/completions` |
-| `视频素材 URL` | 否 | 仅用于视频，每行一个，按已连接 `VIDEO` 的顺序对应；未填写的已连接视频自动使用 Base64 |
+| `视频素材 URL` | 否 | 仅用于视频，每行一个，按已连接 `VIDEO` 的顺序以 `video_url` 透传；未填写的已连接视频自动抽帧成图片发送 |
 
 不再需要、也不要填写单独的“兼容素材上传 URL”。图片没有素材 URL 字段，始终由节点编码成 Base64 并随聊天请求直接发送。
 
 该模式不再使用第二个素材上传端点：
 
 - 图片统一编码为 PNG，通过 `image_url.url` 中的 `data:image/png;base64,...` 内联到同一次 Chat Completions 请求。
-- 视频默认通过 `video_url.url` 中的 `data:video/...;base64,...` 内联完整视频字节。
-- “视频素材 URL”可选，每行一个，按已连接 VIDEO 的顺序替代对应视频的 Base64；未覆盖的视频继续使用 Base64。
+- “视频素材 URL”可选，每行一个，按已连接 VIDEO 的顺序以 `video_url` 原样透传（供声明支持视频内容部件的兼容网关）。
+- 未填写或未覆盖的已连接视频，节点自动抽帧成带时间戳的图片，以 `image_url.url` 的 `data:image/jpeg;base64,...` 发送（适配 llama.cpp 等只接受 `image_url` 的本地视觉模型）。
 - 视频 URL 数量不能超过已连接 VIDEO 数量，且必须是 HTTP(S) 地址。
 
-OpenAI 官方 Chat Completions 明确定义了 Base64 图片输入，但通用 `video_url` 并不是所有兼容供应商都支持的统一能力。这里的视频格式面向声明支持视频理解的兼容网关；用户填写的模型和网关必须同时支持视频内容部件，节点不会降级到纯文字或抽帧请求。
+OpenAI 官方 Chat Completions 定义了 Base64 图片输入，但通用的 `video_url` 并不是所有兼容供应商都支持的统一能力。针对只接受 `image_url` 的端点（例如本地 llama.cpp），节点会把未指定 URL 的视频抽帧成图片再发送，避免请求被 `unsupported content[].type` 拒绝。
 
 ### 本地 GGUF（llama.cpp / Qwen，离线推理）
 

--- a/local_qwen_media.py
+++ b/local_qwen_media.py
@@ -324,6 +324,27 @@ def build_local_media_parts(
     }
 
 
+def sample_video_as_data_urls(
+    value: Any,
+    *,
+    frames_per_second: float,
+    max_frames: int = 9,
+) -> tuple[list[tuple[float, str]], float]:
+    """Sample a native ComfyUI VIDEO into (timestamp, image data URL) pairs.
+
+    Used by OpenAI-compatible endpoints that accept ``image_url`` but reject the
+    nonstandard ``video_url`` part (for example llama.cpp). Only visible video is
+    sampled; audio is never analyzed.
+    """
+    frames, duration = sample_video(value, frames_per_second)
+    selected = _uniform_samples(frames, max(1, int(max_frames)))
+    pairs = [
+        (round(sample.timestamp, 3), _jpeg_data_url(sample.image, quality=86))
+        for sample in selected
+    ]
+    return pairs, duration
+
+
 def estimate_message_tokens(messages: list[dict[str, Any]], visual_tokens_each: int = 1024) -> int:
     text_characters = 0
     visual_parts = 0
@@ -369,4 +390,5 @@ __all__ = [
     "estimate_message_tokens",
     "image_part",
     "sample_video",
+    "sample_video_as_data_urls",
 ]

--- a/nodes.py
+++ b/nodes.py
@@ -174,6 +174,11 @@ except ImportError:
         resolve_case_template,
     )
 
+try:
+    from .local_qwen_media import LocalQwenMediaError, sample_video_as_data_urls
+except ImportError:
+    from local_qwen_media import LocalQwenMediaError, sample_video_as_data_urls
+
 
 API_BASE_URL = "https://api.seedance.nz"
 CHAT_COMPLETIONS_URL = f"{API_BASE_URL}/v1/chat/completions"
@@ -1159,16 +1164,56 @@ def _openai_media_plan(media_plan: list[dict[str, Any]], video_urls_text: str) -
 
         if video_index < len(video_urls):
             video_url = video_urls[video_index]
+            content_parts.append({
+                "type": "text",
+                "text": f"The next attached temporal video is {label}. Analyze its complete timeline.",
+            })
+            content_parts.append({"type": "video_url", "video_url": {"url": video_url}})
         else:
-            data, _extension, mime_type = _video_to_bytes(asset["value"], max_file_bytes=None)
-            video_url = f"data:{mime_type};base64,{base64.b64encode(data).decode('ascii')}"
+            content_parts.extend(_openai_video_parts(asset["value"], label))
         video_index += 1
-        content_parts.append({
-            "type": "text",
-            "text": f"The next attached temporal video is {label}. Analyze its complete timeline.",
-        })
-        content_parts.append({"type": "video_url", "video_url": {"url": video_url}})
     return content_parts
+
+
+_OPENAI_VIDEO_SAMPLE_FPS = DEFAULT_VIDEO_SAMPLE_FPS
+_OPENAI_VIDEO_MAX_FRAMES = 9
+
+
+def _openai_video_parts(value: Any, label: str) -> list[dict[str, Any]]:
+    """Represent an inline (no explicit URL) video as ordered timestamped image frames.
+
+    ``video_url`` is a nonstandard OpenAI part that image-only compatible
+    endpoints (for example llama.cpp) reject with ``unsupported content[].type``.
+    Fall back to the inline ``video_url`` data URI only when the video cannot be
+    decoded into frames, so every existing call site keeps working unchanged.
+    """
+    try:
+        pairs, duration = sample_video_as_data_urls(
+            value,
+            frames_per_second=_OPENAI_VIDEO_SAMPLE_FPS,
+            max_frames=_OPENAI_VIDEO_MAX_FRAMES,
+        )
+    except LocalQwenMediaError:
+        data, _extension, mime_type = _video_to_bytes(value, max_file_bytes=None)
+        video_url = f"data:{mime_type};base64,{base64.b64encode(data).decode('ascii')}"
+        return [
+            {"type": "text", "text": f"The next attached temporal video is {label}. Analyze its complete timeline."},
+            {"type": "video_url", "video_url": {"url": video_url}},
+        ]
+    parts: list[dict[str, Any]] = [
+        {
+            "type": "text",
+            "text": (
+                f"The next attached temporal video is {label}. It is represented by {len(pairs)} ordered "
+                f"timestamped visual samples covering {duration:.3f}s. Read the timestamps in order and describe "
+                f"only visible changes supported by those samples; no audio was analyzed."
+            ),
+        }
+    ]
+    for timestamp, url in pairs:
+        parts.append({"type": "text", "text": f"{label} at {timestamp:.3f}s."})
+        parts.append({"type": "image_url", "image_url": {"url": url}})
+    return parts
 
 
 def _effective_output_language(output_language: str, official_skill_profile: str) -> str:
@@ -1939,7 +1984,7 @@ class MiniMaxH3PromptEnhancer(io.ComfyNode):
                     multiline=True,
                     default="",
                     socketless=True,
-                    tooltip="每行一个，按已连接 VIDEO 顺序替代视频 Base64；未填写或未覆盖的视频仍以内联 Base64 发送。图片始终内联 Base64。",
+                    tooltip="每行一个，按已连接 VIDEO 顺序以 video_url 原样透传（供支持视频的供应商）。未填写或未覆盖的视频自动抽帧成图片以 image_url 发送（适配 llama.cpp 等仅图像端点）。图片始终内联 Base64。",
                 ),
                 io.Int.Input(
                     "seed",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "minimax-h3-seedance-music3-prompt-enhancer-t8"
-version = "1.14.1"
+version = "1.14.2"
 description = "Enhance MiniMax H3 and Seedance 2.0 video prompts and MiniMax Music 3 captions and lyrics with cloud or local Qwen LLM providers."
 authors = [
     { name = "T8mars", email = "20331866@qq.com" },

--- a/seedance20.py
+++ b/seedance20.py
@@ -1204,7 +1204,7 @@ class Seedance20PromptEnhancer(io.ComfyNode):
                     multiline=True,
                     default="",
                     socketless=True,
-                    tooltip="每行一个，按已连接 VIDEO 顺序替代视频 Base64；未填写或未覆盖的视频仍以内联 Base64 发送。图片始终内联 Base64。",
+                    tooltip="每行一个，按已连接 VIDEO 顺序以 video_url 原样透传（供支持视频的供应商）。未填写或未覆盖的视频自动抽帧成图片以 image_url 发送（适配 llama.cpp 等仅图像端点）。图片始终内联 Base64。",
                 ),
                 io.Int.Input(
                     "seed",

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1433,6 +1433,31 @@ class PromptEnhancerTests(unittest.TestCase):
         self.assertTrue(fallback_url.startswith("data:video/mp4;base64,"))
         self.assertEqual(base64.b64decode(fallback_url.split(",", 1)[1]), second_video)
 
+    def test_openai_compatible_inline_video_is_sampled_into_image_url_frames(self):
+        # llama.cpp and other image-only OpenAI-compatible endpoints reject the
+        # nonstandard video_url part with "unsupported content[].type". An inline
+        # (no explicit URL) video must be sampled to image_url frames instead.
+        from PIL import Image
+        from local_qwen_media import SampledFrame
+
+        frames = [
+            SampledFrame(timestamp=0.0, image=Image.new("RGB", (8, 8), (10, 20, 30))),
+            SampledFrame(timestamp=0.5, image=Image.new("RGB", (8, 8), (40, 50, 60))),
+        ]
+        with patch("local_qwen_media.sample_video", return_value=(frames, 1.0)):
+            media_plan = [{"kind": "video", "label": "<Video 1>", "value": FakeVideo()}]
+            parts = nodes._openai_media_plan(media_plan, "")
+        self.assertEqual(
+            [part["type"] for part in parts],
+            ["text", "text", "image_url", "text", "image_url"],
+        )
+        self.assertNotIn("video_url", [part["type"] for part in parts])
+        self.assertEqual(parts[1]["text"], "<Video 1> at 0.000s.")
+        self.assertEqual(parts[3]["text"], "<Video 1> at 0.500s.")
+        self.assertTrue(parts[2]["image_url"]["url"].startswith("data:image/jpeg;base64,"))
+        self.assertTrue(parts[4]["image_url"]["url"].startswith("data:image/jpeg;base64,"))
+        self.assertIn("timestamped visual samples", parts[0]["text"])
+
     def test_node_api_key_overrides_environment_key(self):
         session = FakeSession(basic_output())
         self.run_enhancer(session, api_key="node-key")


### PR DESCRIPTION
## Summary / 概述

Fix `HTTP 400 unsupported content[].type` raised by image-only OpenAI-compatible endpoints (e.g. local llama.cpp serving a vision model like qw38) when a connected `reference_video` is sent as the nonstandard `video_url` part.

修复本地 llama.cpp 这类只接受 `image_url` 的 OpenAI 兼容端点，因节点把 `reference_video` 发成非标准的 `video_url` 而返回 `HTTP 400 unsupported content[].type` 的问题。

## Background / 背景

- `nodes.py::_openai_media_plan()` previously emitted `{"type":"video_url","video_url":{...}}` for every connected video. The OpenAI Chat Completions spec has no `video_url`; llama.cpp / OpenRouter-style proxies accept only `text`, `image_url`, `input_audio`, `input_video`. For a vision model whose `input_modalities` are `["text","image"]`, `video_url` is rejected.
- End-to-end repro on `127.0.0.1:17678` (qw38, Qwen3.8-27B multimodal):
  - `image_url` request → `HTTP 200`
  - `video_url` request → `HTTP 400 unsupported content[].type`

## Change / 改动

- **`local_qwen_media.py`**: add `sample_video_as_data_urls()` — public helper that samples a native ComfyUI `VIDEO` into `(timestamp, image_data_url)` pairs (JPEG, max 9 frames by default). Audio is never analyzed.
- **`nodes.py`**:
  - `_openai_media_plan()` now samples **inline** videos (no explicit `openai_video_urls`) into ordered, timestamped `image_url` frames.
  - Videos with an explicit URL in `openai_video_urls` still pass through as `video_url` (kept as an opt-in for gateways that advertise video support).
  - New `_openai_video_parts()` falls back to the original inline `video_url` data URI only when sampling fails (e.g. test fake streams), so existing call sites stay unchanged.
  - Image handling (`image_url` PNG data URI) is unchanged.
- **`seedance20.py`**: reuses `nodes._openai_media_plan`; tooltip for `openai_video_urls` updated to match.
- **`tests/test_nodes.py`**: new test `test_openai_compatible_inline_video_is_sampled_into_image_url_frames` asserts the sampled-frames behavior and that `video_url` count is 0 in the inline path.
- **`README.md`**: document the new inline-video fallback for local image-only endpoints.
- **`pyproject.toml`**: bump `version` `1.14.1` → `1.14.2` (patch, bug fix).

## Verification / 验证

- `test_openai_compatible_image_is_inlined_as_base64_without_upload` — ok
- `test_openai_compatible_video_supports_direct_url_then_base64_fallback` — ok (fake stream → graceful fallback to old `video_url`)
- `test_ai_workshop_uses_default_model_and_inline_complete_image_and_video` — ok
- `test_seedance20.Seedance20PromptEnhancerTests::test_openai_compatible_uses_base64_images_and_optional_video_urls` — ok
- `test_openai_compatible_inline_video_is_sampled_into_image_url_frames` — ok (new)
- **End-to-end with real 2 s mp4 + qw38 @ 127.0.0.1:17678**: produced `[text,text,image_url,text,image_url,text,image_url,text,image_url]` (4 `image_url`, 0 `video_url`) and returned `HTTP 200`. Pre-fix, the same media emitted as `video_url` returned `HTTP 400`.

## Compatibility / 兼容性

- No API change for users who supply `openai_video_urls`: those videos still pass through as `video_url`.
- Users targeting a `video_url`-capable gateway but *without* filling `openai_video_urls` will now see sampled `image_url` frames instead of `video_url`. This is a strict improvement for image-only endpoints and matches the local GGUF path's behavior.
- AI Workshop and Seedance cloud paths (`_inline_media_plan` / `_upload_media_plan`) are unchanged.

## Notes for maintainers / 维护者备注

- 维护者可自由在此分支上直接编辑 (`Allow edits by maintainers` enabled).
- The repo already has ~900 MB of `web/js/assets/t8-case-previews/*.gif` checked into history, which makes the very first fork-push to a brand-new GitHub fork upload the full pack. To work around that, this PR was pushed after first materialising the common ancestor commit on the fork as a throwaway branch. Consider `git rm --cached` + `.gitignore`ing `web/js/assets/t8-case-previews/*.gif` in a follow-up cleanup commit to shrink clones.